### PR TITLE
Fix for node 6.x. Be explicit about crypto update input encoding latin1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 before_install: npm i -g npm@1.4.28
 node_js:
-  - 0.8
-  - 0.10
+  - 4
+  - 6

--- a/lib/passport-wsfed-saml2/saml.js
+++ b/lib/passport-wsfed-saml2/saml.js
@@ -59,7 +59,7 @@ SAML.prototype.validateSignature = function (xml, options, callback) {
           var base64cer = embeddedSignature[0].firstChild.toString();
           var shasum = crypto.createHash('sha1');
           var der = new Buffer(base64cer, 'base64').toString('binary');
-          shasum.update(der);
+          shasum.update(der, 'latin1');
           self.calculatedThumbprint = shasum.digest('hex');
 
           // using embedded cert, so options.cert is not used anymore

--- a/lib/passport-wsfed-saml2/samlp.js
+++ b/lib/passport-wsfed-saml2/samlp.js
@@ -68,7 +68,7 @@ var removeHeaders = function  (cert) {
 
 var sign = function (content, key, algorithm) {
   var signer = crypto.createSign(algorithm.toUpperCase());
-  signer.update(content);
+  signer.update(content, 'latin1');
   return signer.sign(key, 'base64');
 };
 


### PR DESCRIPTION
As explained [here](https://github.com/nodejs/node/wiki/Breaking-changes-between-v5-and-v6#crypto), [this](https://github.com/nodejs/node/pull/5522) is a breaking change.

Every time this appears `if (!decoder.Decode(env, args[0].As<String>(), args[1], UTF8))`, `args[1]` is the encoding parameter, and `UTF8` is the default.

We need to be explicit about the encoding when calling update. This means using `'latin1'` which is the string that represents the previous `BINARY` constant.